### PR TITLE
Feat: Updated maps URL for better result

### DIFF
--- a/app/components/LocationData/LocationData.js
+++ b/app/components/LocationData/LocationData.js
@@ -25,7 +25,7 @@ const LocationData = ({
         <Paragraph>
           De automatische controle op beschermd stads- of dorpsgezicht is momenteel niet beschikbaar. Controleer
           handmatig op de{' '}
-          <a href="https://maps.amsterdam.nl/cultuurhistorie/?LANG=nl" target="_blank">
+          <a href="https://maps.amsterdam.nl/cultuurhistorie/?LANG=nl&amp;L=6,7" target="_blank">
             Cultuurhistorische waardenkaart op Amsterdam Maps
           </a>{' '}
           of het gebouw in een beschermd stads- of dorpsgezicht ligt.


### PR DESCRIPTION
From: https://maps.amsterdam.nl/cultuurhistorie/?LANG=nl
To: https://maps.amsterdam.nl/cultuurhistorie/?LANG=nl&L=6,7

We can go more specific, by zooming to a certain location, like this:
https://maps.amsterdam.nl/cultuurhistorie/?L=0,6,7&Z=15&C=52.3805002,4.9049423&T=0&N=0&K=52.3705002,4.9049423&P=1
But I don't think it's going to make it more clear.

We can also choose a different theme, but I would say the default theme is the best.
https://maps.amsterdam.nl/cultuurhistorie/?LANG=nl&L=6,7&T=1
https://maps.amsterdam.nl/cultuurhistorie/?LANG=nl&L=6,7&T=2
https://maps.amsterdam.nl/cultuurhistorie/?LANG=nl&L=6,7&T=3
https://maps.amsterdam.nl/cultuurhistorie/?LANG=nl&L=6,7&T=4 (default)