### PR TITLE
Matomo tracking fixes

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -38,7 +38,11 @@ const TOPICS = {
         'U hebt deze informatie nodig om de vergunningcheck dakkapel te doen. De informatie over de bestemmingsplannen is pas nodig als u een omgevingsvergunning gaat aanvragen.',
     },
   },
-  'kappen-of-snoeien': {},
+  'kappen-of-snoeien': {
+    text: {
+      heading: 'Vergunningchecker kappen of snoeien',
+    },
+  },
   'aanbouw-of-uitbouw-maken': {
     status: STATUS.PRE_LIVE,
     text: {

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -75,7 +75,10 @@ export const App = props => {
   // @datapunt Track Page View
   // Docu: https://github.com/Amsterdam/matomo-tracker/tree/master/packages/react
   React.useEffect(() => {
-    trackPageView();
+    if (props.location.pathname.split('/')[2]) {
+      // Don't track root redirects (/dakraam-plaatsen), only track subpages (/dakraam-plaatsen/introductie)
+      trackPageView();
+    }
   }, [props.location.pathname]);
 
   return (

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { Switch, Route, withRouter, Redirect } from 'react-router-dom';
 import { compose } from 'redux';
@@ -75,8 +76,8 @@ export const App = props => {
   // @datapunt Track Page View
   // Docu: https://github.com/Amsterdam/matomo-tracker/tree/master/packages/react
   React.useEffect(() => {
-    if (props.location.pathname.split('/')[2]) {
-      // Don't track root redirects (/dakraam-plaatsen), only track subpages (/dakraam-plaatsen/introductie)
+    if (REDIRECT_TO_OLO || props.location.pathname.split('/')[2]) {
+      // Only track direct redirects to OLO or pages part of a flow, like (/dakraam-plaatsen/introductie)
       trackPageView();
     }
   }, [props.location.pathname]);
@@ -103,7 +104,17 @@ export const App = props => {
             </Content>
             <Switch>
               {/* REDIRECTS */}
-              {REDIRECT_TO_OLO && window.open(`${EXTERNAL_URLS.oloChecker.intro}`, '_self')}
+              {REDIRECT_TO_OLO && (
+                <Helmet>
+                  <title>Redirect naar OLO - {GET_TEXT?.heading}</title>
+                </Helmet>
+              )}
+              {REDIRECT_TO_OLO &&
+                setTimeout(() => {
+                  // Timout makes sure Matomo tracker is loaded on page
+                  window.open(`${EXTERNAL_URLS.oloChecker.intro}`, '_self');
+                }, 200)}
+
               {ALLOW_LOCATION_PAGE && (
                 <Redirect
                   exact

--- a/app/containers/Checker/ConclusionsPage.js
+++ b/app/containers/Checker/ConclusionsPage.js
@@ -47,7 +47,6 @@ const ConclusionsPage = () => {
 
           if (conclusionString !== '"Toestemmingsvrij"') {
             authorized = true;
-            console.log('set authorized on false');
           }
 
           return (

--- a/app/containers/Location/CheckerPage.js
+++ b/app/containers/Location/CheckerPage.js
@@ -91,10 +91,9 @@ const LocationPage = ({ addressResultsLoading, bagLoading, onFetchBagData, addre
       }
 
       trackEvent({
-        category: 'location',
-        action: 'postcode',
-        name: GET_CURRENT_TOPIC(),
-        value: currentValues.postalCode.substring(0, 4),
+        category: 'postcode-input',
+        action: `postcode - ${GET_CURRENT_TOPIC()}`,
+        name: currentValues.postalCode.substring(0, 4),
       });
 
       history.push(`/${GET_CURRENT_TOPIC()}/${PAGES.locationResult}`);


### PR DESCRIPTION
- Don't track root redirects
- Don't track OLO redirects
- Only track subpages
- Track postcode